### PR TITLE
Use async requests for Mistral API, with leaky bucket rate limiting.

### DIFF
--- a/enclaveid_data_pipeline/assets/recent_history.py
+++ b/enclaveid_data_pipeline/assets/recent_history.py
@@ -1,12 +1,10 @@
 import math
 import os
-from functools import partial
 from textwrap import dedent
 
 import polars as pl
 import psycopg
-from dagster import AssetExecutionContext, DagsterLogManager, asset
-from mistralai.client import MistralClient
+from dagster import AssetExecutionContext, asset
 from pgvector.psycopg import register_vector
 from pydantic import Field
 
@@ -14,7 +12,11 @@ from ..partitions import user_partitions_def
 from ..resources.mistral_resource import MistralResource
 from ..resources.postgres_resource import PGVectorClient, PGVectorClientResource
 from ..utils.custom_config import RowLimitConfig
-from ..utils.recent_history_utils import ChunkedSessionOutput, get_daily_sessions
+from ..utils.recent_history_utils import (
+    ChunkedSessionOutput,
+    get_daily_sessions,
+    get_embeddings,
+)
 
 # TODO: Avoid auto-committing queries and bundle them as one transaction,
 # where appropriate.
@@ -120,26 +122,6 @@ async def recent_sessions(
     return pl.concat((out.output_df for out in daily_outputs))
 
 
-# TODO: Consider making this a method of the MistralResource.
-def get_embeddings(
-    texts: pl.Series, client: MistralClient, chunk_size: int, logger: DagsterLogManager
-) -> pl.Series:
-    # TODO: Maybe we want to make this async?
-    num_chunks = math.ceil(len(texts) / chunk_size)
-    embeddings = []
-    for idx in range(0, len(texts), chunk_size):
-        logger.info(f"Processing chunk {int(idx/chunk_size) + 1} / {num_chunks}")
-
-        response = client.embeddings(
-            model="mistral-embed",
-            input=texts.slice(idx, chunk_size).to_list(),
-        )
-
-        embeddings.extend(x.embedding for x in response.data)
-
-    return pl.Series(embeddings, dtype=pl.Array(pl.Float64, 1024))
-
-
 # TODO: Consider encapsulating this logic in an IOManager and/or moving the binary
 # copy logic into the PGVectorClient.
 def upload_embeddings(
@@ -197,7 +179,29 @@ def upload_embeddings(
 
 
 class SessionEmbeddingsConfig(RowLimitConfig):
-    chunk_size: int = Field(default=100, description="The size of each chunk.")
+    batch_size: int = Field(
+        default=100,
+        description=(
+            "Mistral allows passing a batch of multiple strings to the embeddings "
+            "endpoint as a single request, maximising throughput. However, a "
+            "single batch can only have a maximum  of 16,384 tokens. Reduce the "
+            "batch size if the API returns a 'Too many tokens in batch.' error"
+        ),
+    )
+    model_name: str = Field(
+        default="mistral-embed",
+        description=(
+            "The Mistral model to use. See the Mistral docs for a list of valid "
+            "endpoints: https://docs.mistral.ai/platform/endpoints/"
+        ),
+    )
+    rate_limit: float = Field(
+        default=5.0,
+        description=(
+            "The maximum number of requests allowed per second. See the Mistral "
+            "docs here: https://docs.mistral.ai/platform/pricing/"
+        ),
+    )
 
 
 # TODO: Consider incorporate this logic inside recent_sessions.
@@ -205,7 +209,7 @@ class SessionEmbeddingsConfig(RowLimitConfig):
     partitions_def=user_partitions_def,
     io_manager_key="parquet_io_manager",
 )
-def recent_session_embeddings(
+async def recent_session_embeddings(
     context: AssetExecutionContext,
     config: SessionEmbeddingsConfig,
     mistral: MistralResource,
@@ -215,17 +219,21 @@ def recent_session_embeddings(
     # Enforce row_limit (if any)
     recent_sessions = recent_sessions.slice(0, config.row_limit)
 
-    context.log.info("Getting embeddings...")
-    client = mistral.get_client()
+    num_chunks = math.ceil(len(recent_sessions) / config.batch_size)
+    context.log.info(f"Getting embeddings for {num_chunks} chunks...")
+
+    client = mistral.get_async_client()
+    embeddings = await get_embeddings(
+        texts=recent_sessions.get_column("description"),
+        client=client,
+        batch_size=config.batch_size,
+        logger=context.log,
+        rate_limit=config.rate_limit,
+        model=config.model_name,
+    )
+
     recent_sessions = recent_sessions.with_columns(
-        embedding=pl.col("description").map_batches(
-            partial(
-                get_embeddings,
-                client=client,
-                chunk_size=config.chunk_size,
-                logger=context.log,
-            )
-        ),
+        embedding=embeddings,
         user_id=pl.lit(context.partition_key),
     )
 

--- a/enclaveid_data_pipeline/resources/mistral_resource.py
+++ b/enclaveid_data_pipeline/resources/mistral_resource.py
@@ -1,4 +1,5 @@
 from dagster import ConfigurableResource
+from mistralai.async_client import MistralAsyncClient
 from mistralai.client import MistralClient
 from pydantic import Field
 
@@ -8,3 +9,6 @@ class MistralResource(ConfigurableResource):
 
     def get_client(self) -> MistralClient:
         return MistralClient(api_key=self.api_key)
+
+    def get_async_client(self) -> MistralAsyncClient:
+        return MistralAsyncClient(api_key=self.api_key)

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ setup(
     packages=find_packages(exclude=["enclaveid_data_pipeline_tests"]),
     install_requires=[
         "adlfs",
+        "aiolimiter",
         "dagster>=1.6.0,<1.7.0",
         "dagster-cloud",
         "dagster-polars",


### PR DESCRIPTION
This PR implements the use of async requests when calling the Mistral API for the `recent_history` assets. It also makes the rate limit and the Mistral endpoint used in both `recent_sessions` and `recent_session_embeddings` configurable via the Dagster UI.

A rudimentary comparison between the sequential and async implementations with a `row_limit=10000` yields:

- a 5.42x for `recent_sessions` (2m38s vs. 14m17s)
- a 2x speedup for `recent_session_embeddings` (4s vs. 2s).

A ~5x speedup is in line with our current rate limit (5 requests per second), which is rather small, and asking for a larger rate limit should speed up the process even further.

Using async requests for `recent_session_embeddings` doesn't yield a very significant speedup because the cardinality of the input for `recent_session_embeddings` is much smaller than for `recent_sessions` (e.g., imposing a `row_limit` of 10K on the input to `recent_sessions` results in only ~400 sessions in the output, which is used as the input for `recent_session_embeddings`). 

Additionally, unlike the `chat` endpoint, where each string must be sent as a single request, the `embeddings` endpoint allows batching multiple strings into a single request. With a default batch size of 100, we don't make many requests in the first place (e.g., 400 sessions only require 4 requests), so the difference between sequential vs. async calls isn't very pronounced. A run on the full data might make the difference a bit more obvious.