### PR TITLE
Install cuml using a post_install.sh script.

### DIFF
--- a/dagster_cloud_post_install.sh
+++ b/dagster_cloud_post_install.sh
@@ -1,0 +1,3 @@
+# TODO: Decide if this is needed after a decision on infrastructure for GPU assets
+# (i.e., whether to use SkyPilot or a Hybrid deployment) is made.
+pip install --extra-index-url=https://pypi.nvidia.com cuml-cu12==24.2.*

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,10 @@ setup(
         # "skypilot[azure]",
         "tqdm",
         "universal_pathlib",
+        "vllm>=0.4.0",
+        "sentence-transformers",
+        "cupy-cuda12x",
+        "hdbscan",
     ],
     extras_require={
         "dev": [
@@ -30,10 +34,6 @@ setup(
             "ipykernel",
             "ipywidgets",
             "ruff",
-            "vllm>=0.4.0",
-            "sentence-transformers",
-            "cupy-cuda12x",
-            "hdbscan",
         ]
     },
 )


### PR DESCRIPTION
Because `cuml` depends on a custom package index (https://pypi.nvidia.com), there isn't an easy way to add it as a dependency using `setup.py`. Instead, we install it with a direct `pip install` call using the `dagster_cloud_post_install.sh` script.